### PR TITLE
Passage du champ `counter_id ` en optionnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Ce fichier répertorie les changements entre différentes versions d'un schéma.
 
+## Version 0.2.4 du 2023-05-15
+
+Passage du champ `counter_id`, qui était un champ obligatoire, en champ optionnel dans le sous-schéma measure. 
+
 ## Version 0.2.3 du 2023-04-07
 
 Première publication en datapackage du schéma de comptage des mobilités. 

--- a/channel/schema.json
+++ b/channel/schema.json
@@ -20,17 +20,17 @@
       {
          "title": "Fichier valide (CSV)",
          "name": "exemple-valide-csv",
-         "path": "https://raw.githubusercontent.com/etalab/schema-comptage-mobilites/v0.2.3/channel/exemple-valide.csv"
+         "path": "https://raw.githubusercontent.com/etalab/schema-comptage-mobilites/v0.2.4/channel/exemple-valide.csv"
       },
       {
          "title": "Deuxième fichier valide (CSV)",
          "name": "exemple-valide-eco-compteur.csv",
-         "path": "https://raw.githubusercontent.com/etalab/schema-comptage-mobilites/v0.2.3/channel/exemple-valide-eco-compteur.csv"
+         "path": "https://raw.githubusercontent.com/etalab/schema-comptage-mobilites/v0.2.4/channel/exemple-valide-eco-compteur.csv"
       }
    ],
    "created": "2021-05-06",
-   "lastModified": "2023-04-07",
-   "version": "0.2.3",
+   "lastModified": "2023-05-15",
+   "version": "0.2.4",
    "contributors": [
       {
          "title": "Miryad Ali",

--- a/measure/schema.json
+++ b/measure/schema.json
@@ -20,17 +20,17 @@
       {
          "title": "Fichier valide (CSV)",
          "name": "exemple-valide-csv",
-         "path": "https://raw.githubusercontent.com/etalab/schema-comptage-mobilites/v0.2.3/measure/exemple-valide.csv"
+         "path": "https://raw.githubusercontent.com/etalab/schema-comptage-mobilites/v0.2.4/measure/exemple-valide.csv"
       },
       {
          "title": "Deuxième fichier valide (CSV)",
          "name": "exemple-valide-eco-compteur.csv",
-         "path": "https://raw.githubusercontent.com/etalab/schema-comptage-mobilites/v0.2.3/measure/exemple-valide-eco-compteur.csv"
+         "path": "https://raw.githubusercontent.com/etalab/schema-comptage-mobilites/v0.2.4/measure/exemple-valide-eco-compteur.csv"
       }
    ],
    "created": "2021-11-15",
-   "lastModified": "2023-04-07",
-   "version": "0.2.3",
+   "lastModified": "2023-05-15",
+   "version": "0.2.4",
    "contributors": [
       {
          "title": "Miryad Ali",
@@ -73,7 +73,7 @@
          "example": "C01-Baix",
          "type": "string",
          "constraints": {
-            "required": true
+            "required": false
          }
       },
       {

--- a/site/schema.json
+++ b/site/schema.json
@@ -20,17 +20,17 @@
       {
          "title": "Fichier valide (CSV)",
          "name": "exemple-valide-csv",
-         "path": "https://raw.githubusercontent.com/etalab/schema-comptage-mobilites/v0.2.3/site/exemple-valide.csv"
+         "path": "https://raw.githubusercontent.com/etalab/schema-comptage-mobilites/v0.2.4/site/exemple-valide.csv"
       },
       {
          "title": "Deuxième fichier valide (CSV)",
          "name": "exemple-valide-eco-compteur.csv",
-         "path": "https://raw.githubusercontent.com/etalab/schema-comptage-mobilites/v0.2.3/site/exemple-valide-eco-compteur.csv"
+         "path": "https://raw.githubusercontent.com/etalab/schema-comptage-mobilites/v0.2.4/site/exemple-valide-eco-compteur.csv"
       }
    ],
    "created": "2021-05-06",
-   "lastModified": "2023-04-07",
-   "version": "0.2.3",
+   "lastModified": "2023-05-15",
+   "version": "0.2.4",
    "contributors": [
       {
          "title": "Miryad Ali",


### PR DESCRIPTION
Passage du champ `counter_id ` en optionnel : https://github.com/etalab/schema-comptage-mobilites/issues/3

Vous publiez une nouvelle version d'un schéma ?
Pensez à réaliser les actions suivantes.

- [x] Mettre à jour les fichiers d'exemples
- [x] Mettre à jour le champ `version`
- [x] Mettre à jour le champ `lastModified`
- [x] Changer les liens vers les fichiers d'exemples présents dans `schema.json` et `README.md`
- [x] Mettre à jour le fichier `CHANGELOG.md` en incluant une description de la version
- [x] Merger cette pull-request
- [x] Publier un nouveau tag et une nouvelle version
- [ ] Prévenir les utilisateurs de ce schéma